### PR TITLE
42 sprint 7   implementar validações para a tela unitofmeasure

### DIFF
--- a/SeniorStockManagerFrontend/src/pages/Registrations/RegisterUnitOfMeasure.tsx
+++ b/SeniorStockManagerFrontend/src/pages/Registrations/RegisterUnitOfMeasure.tsx
@@ -93,6 +93,26 @@ export default function UnitOfMeasureRegistration() {
 
     setModalEdit((isOpen) => !isOpen);
   };
+  const validate = (unitOfMeasure: UnitOfMeasure) => {
+    if (unitOfMeasure.abbreviation === null) {
+      alert('Abreviação não pode ser nulo');
+      return false;
+    }
+    if (unitOfMeasure.description === null) {
+      alert('Descrição não pode ser nulo')
+      return false;
+    }
+    if (unitOfMeasure.description.length > 50) {
+      alert('Campo descrição deve conter menos de 50 caracteres')
+      return false;
+    }
+    if (unitOfMeasure.abbreviation.length > 50){
+      alert('Campo abreviação deve conter menos de 50 caracteres')
+      return false;
+    }
+
+    return true;
+  }
 
   // Abre a modal para deleção pegando os dados da linha
   const openCloseModalDelete = (id?: number) => {
@@ -120,6 +140,8 @@ export default function UnitOfMeasureRegistration() {
   };
 
   const registerUnitOfMeasure = async (model: UnitOfMeasure) => {
+    if(!validate(model)) return;
+
     const unitOfMeasure = new UnitOfMeasureService();
     const res = await unitOfMeasure.create({
       ...model,
@@ -135,6 +157,8 @@ export default function UnitOfMeasureRegistration() {
   };
 
   const editUnitOfMeasure = async (id: number, model: UnitOfMeasure) => {
+    if (!validate(model)) return;
+
     const unitOfMeasure = new UnitOfMeasureService();
     const res = await unitOfMeasure.update(id, model);
     if (res.code === 200) {

--- a/SeniorStockManagerFrontend/src/pages/Registrations/RegisterUnitOfMeasure.tsx
+++ b/SeniorStockManagerFrontend/src/pages/Registrations/RegisterUnitOfMeasure.tsx
@@ -94,20 +94,20 @@ export default function UnitOfMeasureRegistration() {
     setModalEdit((isOpen) => !isOpen);
   };
   const validate = (unitOfMeasure: UnitOfMeasure) => {
-    if (unitOfMeasure.abbreviation === null) {
-      alert('Abreviação não pode ser nulo');
+    if (unitOfMeasure.abbreviation.trim() === '') {
+      alert('Abreviação não pode ser nula ou vazia');
       return false;
     }
-    if (unitOfMeasure.description === null) {
-      alert('Descrição não pode ser nulo')
+    if (unitOfMeasure.description.trim() === '') {
+      alert('Descrição não pode ser nula ou vazia');
       return false;
     }
-    if (unitOfMeasure.description.length > 50) {
-      alert('Campo descrição deve conter menos de 50 caracteres')
+    if (unitOfMeasure.description.trim().length > 50) {
+      alert('Campo descrição deve conter menos de 50 caracteres');
       return false;
     }
-    if (unitOfMeasure.abbreviation.length > 50){
-      alert('Campo abreviação deve conter menos de 50 caracteres')
+    if (unitOfMeasure.abbreviation.trim().length > 50) {
+      alert('Campo abreviação deve conter menos de 50 caracteres');
       return false;
     }
 


### PR DESCRIPTION
Título do PR: Implementar validações para unit of measure
Implementação de validações concluídas.

Contexto: Validações implementadas para que o usuário nao cadastre nenhum campo vazio ou acima de 50 caracteres.
Screenshots (se aplicável):
<img width="973" height="639" alt="image" src="https://github.com/user-attachments/assets/8eb2cbca-7e3e-426b-a1ea-fc800133bbae" />
<img width="579" height="589" alt="image" src="https://github.com/user-attachments/assets/163c2768-e537-4d33-b84a-5acdb894f137" />

